### PR TITLE
key-pairs region-specific

### DIFF
--- a/docs/5_Compute/5a_EC2/EC2_Concepts.md
+++ b/docs/5_Compute/5a_EC2/EC2_Concepts.md
@@ -5,4 +5,5 @@
 * **Notes:**
   * Occupies single AZ, single host in that AZ.
   * Security groups associated with network interface, not the instance.
-  * Key Pairs are globally available in AWS, they are not region specific.
+  * Key Pairs are region-specific (although [you can upload the same key pair to all the regions](https://aws.amazon.com/premiumsupport/knowledge-center/ec2-ssh-key-pair-regions/))
+  


### PR DESCRIPTION
Correcting the info on key-pairs. I don't think they are global, see:
- https://aws.amazon.com/premiumsupport/knowledge-center/ec2-ssh-key-pair-regions/
- https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html says:

> You can have up to 5,000 key pairs **per Region**.  

(emphasis mine)